### PR TITLE
Removing the master and slave lingo

### DIFF
--- a/env/Lib/site-packages/boto/emr/connection.py
+++ b/env/Lib/site-packages/boto/emr/connection.py
@@ -204,8 +204,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -229,11 +229,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -264,7 +264,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -299,15 +299,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -443,15 +443,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/env/Lib/site-packages/boto/emr/step.py
+++ b/env/Lib/site-packages/boto/emr/step.py
@@ -124,7 +124,7 @@ class StreamingStep(Step):
         :type output: str
         :param output: The output uri
         :type jar: str
-        :param jar: The hadoop streaming jar. This can be either a local path on the master node, or an s3:// URI.
+        :param jar: The hadoop streaming jar. This can be either a local path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/env/Lib/site-packages/boto/pyami/bootstrap.py
+++ b/env/Lib/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/env/Lib/site-packages/boto/rds/__init__.py
+++ b/env/Lib/site-packages/boto/rds/__init__.py
@@ -143,8 +143,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -171,8 +171,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -221,8 +221,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-ex
                        * sqlserver-web
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -239,8 +239,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -368,8 +368,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -389,8 +389,8 @@ class RDSConnection(AWSQueryConnection):
                   'Engine': engine,
                   'EngineVersion': engine_version,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -483,7 +483,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -505,8 +505,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -564,8 +564,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/env/Lib/site-packages/boto/rds/dbinstance.py
+++ b/env/Lib/site-packages/boto/rds/dbinstance.py
@@ -41,7 +41,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_group: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -75,7 +75,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -121,8 +121,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -212,7 +212,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -230,8 +230,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -278,7 +278,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/env/Lib/site-packages/boto/rds/dbsnapshot.py
+++ b/env/Lib/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     """
     
     def __init__(self, connection=None, id=None):
@@ -49,7 +49,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -77,8 +77,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/env/Lib/site-packages/django/apps/registry.py
+++ b/env/Lib/site-packages/django/apps/registry.py
@@ -20,7 +20,7 @@ class Apps(object):
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -51,7 +51,7 @@ class Apps(object):
         # Pending lookups for lazy relations.
         self._pending_lookups = {}
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/env/Lib/site-packages/django/conf/global_settings.py
+++ b/env/Lib/site-packages/django/conf/global_settings.py
@@ -232,7 +232,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/env/Lib/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/env/Lib/site-packages/django/db/backends/sqlite3/introspection.py
@@ -58,7 +58,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -78,7 +78,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         try:
             results = cursor.fetchone()[0].strip()
         except TypeError:
@@ -100,7 +100,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -126,7 +126,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -171,7 +171,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         row = cursor.fetchone()
         if row is None:
             raise ValueError("Table %s does not exist" % table_name)

--- a/env/Lib/site-packages/django/test/_doctest.py
+++ b/env/Lib/site-packages/django/test/_doctest.py
@@ -1530,7 +1530,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1824,7 +1824,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1886,13 +1886,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1923,10 +1923,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -2004,13 +2004,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -2046,10 +2046,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/env/Lib/site-packages/django/test/client.py
+++ b/env/Lib/site-packages/django/test/client.py
@@ -401,7 +401,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/env/Lib/site-packages/markdown/blockprocessors.py
+++ b/env/Lib/site-packages/markdown/blockprocessors.py
@@ -209,7 +209,7 @@ class CodeBlockProcessor(BlockProcessor):
             code.text = markdown.AtomicString('%s\n' % block.rstrip())
         if theRest:
             # This block contained unindented line(s) after the first indented 
-            # line. Insert these lines as the first block of the master blocks
+            # line. Insert these lines as the first block of the main blocks
             # list for future processing.
             blocks.insert(0, theRest)
 
@@ -377,7 +377,7 @@ class SetextHeaderProcessor(BlockProcessor):
         h = markdown.etree.SubElement(parent, 'h%d' % level)
         h.text = lines[0].strip()
         if len(lines) > 2:
-            # Block contains additional lines. Add to  master blocks for later.
+            # Block contains additional lines. Add to  main blocks for later.
             blocks.insert(0, '\n'.join(lines[2:]))
 
 
@@ -411,7 +411,7 @@ class HRProcessor(BlockProcessor):
         # check for lines in block after hr.
         lines = lines[len(prelines)+1:]
         if len(lines):
-            # Add lines after hr to master blocks for later parsing.
+            # Add lines after hr to main blocks for later parsing.
             blocks.insert(0, '\n'.join(lines))
 
 
@@ -429,7 +429,7 @@ class EmptyBlockProcessor(BlockProcessor):
         block = blocks.pop(0)
         m = self.RE.match(block)
         if m:
-            # Add remaining line to master blocks for later.
+            # Add remaining line to main blocks for later.
             blocks.insert(0, block[m.end():])
             sibling = self.lastChild(parent)
             if sibling and sibling.tag == 'pre' and sibling[0] and \

--- a/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
+++ b/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
@@ -644,9 +644,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3016,9 +3016,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3028,7 +3028,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/Lib/site-packages/pip/vcs/git.py
+++ b/env/Lib/site-packages/pip/vcs/git.py
@@ -118,7 +118,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         if rev_options:
             rev_options = self.check_rev_options(
                 rev_options[0], dest, rev_options,
@@ -133,7 +133,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['origin/main']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(

--- a/env/Lib/site-packages/pkg_resources/__init__.py
+++ b/env/Lib/site-packages/pkg_resources/__init__.py
@@ -619,9 +619,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -2925,9 +2925,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -2937,7 +2937,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/Lib/site-packages/pymysql/tests/test_basic.py
+++ b/env/Lib/site-packages/pymysql/tests/test_basic.py
@@ -177,7 +177,7 @@ class TestCursor(base.PyMySQLTestCase):
     #         ('Create_tmp_table_priv', 254, 1, 1, 1, 0, 0),
     #         ('Lock_tables_priv', 254, 1, 1, 1, 0, 0),
     #         ('Execute_priv', 254, 1, 1, 1, 0, 0),
-    #         ('Repl_slave_priv', 254, 1, 1, 1, 0, 0),
+    #         ('Repl_subordinate_priv', 254, 1, 1, 1, 0, 0),
     #         ('Repl_client_priv', 254, 1, 1, 1, 0, 0),
     #         ('Create_view_priv', 254, 1, 1, 1, 0, 0),
     #         ('Show_view_priv', 254, 1, 1, 1, 0, 0),

--- a/env/Lib/site-packages/setuptools/command/easy_install.py
+++ b/env/Lib/site-packages/setuptools/command/easy_install.py
@@ -1688,7 +1688,7 @@ def update_dist_caches(dist_path, fix_zipimporter_caches):
     # There are several other known sources of stale zipimport.zipimporter
     # instances that we do not clear here, but might if ever given a reason to
     # do so:
-    # * Global setuptools pkg_resources.working_set (a.k.a. 'master working
+    # * Global setuptools pkg_resources.working_set (a.k.a. 'main working
     # set') may contain distributions which may in turn contain their
     #   zipimport.zipimporter loaders.
     # * Several zipimport.zipimporter loaders held by local variables further

--- a/env/Lib/sre_parse.py
+++ b/env/Lib/sre_parse.py
@@ -63,7 +63,7 @@ FLAGS = {
 }
 
 class Pattern:
-    # master pattern object.  keeps track of global attributes
+    # main pattern object.  keeps track of global attributes
     def __init__(self):
         self.flags = 0
         self.open = []

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/emr/connection.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/emr/connection.py
@@ -204,8 +204,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -229,11 +229,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -264,7 +264,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -299,15 +299,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -443,15 +443,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/emr/step.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/emr/step.py
@@ -124,7 +124,7 @@ class StreamingStep(Step):
         :type output: str
         :param output: The output uri
         :type jar: str
-        :param jar: The hadoop streaming jar. This can be either a local path on the master node, or an s3:// URI.
+        :param jar: The hadoop streaming jar. This can be either a local path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/pyami/bootstrap.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/rds/__init__.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/rds/__init__.py
@@ -143,8 +143,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -171,8 +171,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -221,8 +221,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-ex
                        * sqlserver-web
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -239,8 +239,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -368,8 +368,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -389,8 +389,8 @@ class RDSConnection(AWSQueryConnection):
                   'Engine': engine,
                   'EngineVersion': engine_version,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -483,7 +483,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -505,8 +505,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -564,8 +564,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/rds/dbinstance.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/rds/dbinstance.py
@@ -41,7 +41,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_group: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -75,7 +75,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -121,8 +121,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -212,7 +212,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -230,8 +230,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -278,7 +278,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/rds/dbsnapshot.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     """
     
     def __init__(self, connection=None, id=None):
@@ -49,7 +49,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -77,8 +77,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/apps/registry.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/apps/registry.py
@@ -20,7 +20,7 @@ class Apps(object):
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -51,7 +51,7 @@ class Apps(object):
         # Pending lookups for lazy relations.
         self._pending_lookups = {}
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/conf/global_settings.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/conf/global_settings.py
@@ -232,7 +232,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/db/backends/sqlite3/introspection.py
@@ -58,7 +58,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -78,7 +78,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         try:
             results = cursor.fetchone()[0].strip()
         except TypeError:
@@ -100,7 +100,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -126,7 +126,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -171,7 +171,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         row = cursor.fetchone()
         if row is None:
             raise ValueError("Table %s does not exist" % table_name)

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/test/_doctest.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/test/_doctest.py
@@ -1530,7 +1530,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1824,7 +1824,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1886,13 +1886,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1923,10 +1923,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -2004,13 +2004,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -2046,10 +2046,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/test/client.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/django/test/client.py
@@ -401,7 +401,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/markdown/blockprocessors.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/markdown/blockprocessors.py
@@ -209,7 +209,7 @@ class CodeBlockProcessor(BlockProcessor):
             code.text = markdown.AtomicString('%s\n' % block.rstrip())
         if theRest:
             # This block contained unindented line(s) after the first indented 
-            # line. Insert these lines as the first block of the master blocks
+            # line. Insert these lines as the first block of the main blocks
             # list for future processing.
             blocks.insert(0, theRest)
 
@@ -377,7 +377,7 @@ class SetextHeaderProcessor(BlockProcessor):
         h = markdown.etree.SubElement(parent, 'h%d' % level)
         h.text = lines[0].strip()
         if len(lines) > 2:
-            # Block contains additional lines. Add to  master blocks for later.
+            # Block contains additional lines. Add to  main blocks for later.
             blocks.insert(0, '\n'.join(lines[2:]))
 
 
@@ -411,7 +411,7 @@ class HRProcessor(BlockProcessor):
         # check for lines in block after hr.
         lines = lines[len(prelines)+1:]
         if len(lines):
-            # Add lines after hr to master blocks for later parsing.
+            # Add lines after hr to main blocks for later parsing.
             blocks.insert(0, '\n'.join(lines))
 
 
@@ -429,7 +429,7 @@ class EmptyBlockProcessor(BlockProcessor):
         block = blocks.pop(0)
         m = self.RE.match(block)
         if m:
-            # Add remaining line to master blocks for later.
+            # Add remaining line to main blocks for later.
             blocks.insert(0, block[m.end():])
             sibling = self.lastChild(parent)
             if sibling and sibling.tag == 'pre' and sibling[0] and \

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
@@ -644,9 +644,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3016,9 +3016,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3028,7 +3028,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/pip/vcs/git.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/pip/vcs/git.py
@@ -118,7 +118,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         if rev_options:
             rev_options = self.check_rev_options(
                 rev_options[0], dest, rev_options,
@@ -133,7 +133,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['origin/main']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/pkg_resources/__init__.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/pkg_resources/__init__.py
@@ -619,9 +619,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -2925,9 +2925,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -2937,7 +2937,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/pymysql/tests/test_basic.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/pymysql/tests/test_basic.py
@@ -177,7 +177,7 @@ class TestCursor(base.PyMySQLTestCase):
     #         ('Create_tmp_table_priv', 254, 1, 1, 1, 0, 0),
     #         ('Lock_tables_priv', 254, 1, 1, 1, 0, 0),
     #         ('Execute_priv', 254, 1, 1, 1, 0, 0),
-    #         ('Repl_slave_priv', 254, 1, 1, 1, 0, 0),
+    #         ('Repl_subordinate_priv', 254, 1, 1, 1, 0, 0),
     #         ('Repl_client_priv', 254, 1, 1, 1, 0, 0),
     #         ('Create_view_priv', 254, 1, 1, 1, 0, 0),
     #         ('Show_view_priv', 254, 1, 1, 1, 0, 0),

--- a/obj/Release/Package/PackageTmp/env/Lib/site-packages/setuptools/command/easy_install.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/site-packages/setuptools/command/easy_install.py
@@ -1688,7 +1688,7 @@ def update_dist_caches(dist_path, fix_zipimporter_caches):
     # There are several other known sources of stale zipimport.zipimporter
     # instances that we do not clear here, but might if ever given a reason to
     # do so:
-    # * Global setuptools pkg_resources.working_set (a.k.a. 'master working
+    # * Global setuptools pkg_resources.working_set (a.k.a. 'main working
     # set') may contain distributions which may in turn contain their
     #   zipimport.zipimporter loaders.
     # * Several zipimport.zipimporter loaders held by local variables further

--- a/obj/Release/Package/PackageTmp/env/Lib/sre_parse.py
+++ b/obj/Release/Package/PackageTmp/env/Lib/sre_parse.py
@@ -63,7 +63,7 @@ FLAGS = {
 }
 
 class Pattern:
-    # master pattern object.  keeps track of global attributes
+    # main pattern object.  keeps track of global attributes
     def __init__(self):
         self.flags = 0
         self.open = []


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.